### PR TITLE
Fix failing spec 

### DIFF
--- a/spec/embedly/command_line_spec.rb
+++ b/spec/embedly/command_line_spec.rb
@@ -13,7 +13,7 @@ module Embedly
       let(:api) { mock(API) }
 
       it "calls api with options" do
-        API.should_receive(:new).with(:key => 'MY_KEY', :headers => {}) { api }
+        API.should_receive(:new).with(:key => 'MY_KEY', :headers => {}, :typhoeus => true) { api }
         api.should_receive(:oembed).with(:urls => ['http://yfrog.com/h7qqespj'], :maxwidth => '10')
         CommandLine.run!(:oembed, arguments)
       end


### PR DESCRIPTION
Ensure that api receive the proper options since typhoeus is currently the default.
