### PR TITLE
Reject urls that are too long

### DIFF
--- a/features/oembed.feature
+++ b/features/oembed.feature
@@ -78,3 +78,14 @@ Feature: OEmbed
             | http://www.youtube.com/watch/a/bassd/url,http://www.youtube.com/watch/ldf/asdlfj | 404,404 | error,error |
             | http://www.youtube.com/watch/zzzzasdf/kl,http://yfrog.com/h7qqespj               | 404,    | error,photo |
             | http://yfrog.com/h7qqespj,http://www.youtube.com/watch/asdfasdfasdf              | ,404    | photo,error |
+            
+    Scenario Outline: Attempt to get 414 URL
+        Given an embedly api with key
+        When oembed is called with the <url> URL
+        Then type should be error
+        And error_code should be 414
+        And type should be error
+
+        Examples:
+            | url |
+            | http://www.youtube.com/watch/is/a/bad/url/because/it/is/longer/than/2048/characters/this/is/much/too/long/for/a/url/and/shouldnt/even/be/sent/to/the/server/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|

--- a/lib/embedly/api.rb
+++ b/lib/embedly/api.rb
@@ -120,17 +120,24 @@ class Embedly::API
 
     # store unsupported services as errors and don't send them to embedly
     rejects = []
-    if not key
-      params[:urls].reject!.with_index do |url, i|
-        if url !~ services_regex
-          rejects << [i,
-            Embedly::EmbedlyObject.new(
-              :type => 'error',
-              :error_code => 401,
-              :error_message => 'Embedly api key is required.'
-            )
-          ]
-        end
+
+    params[:urls].reject!.with_index do |url, i|
+      if !key && url !~ services_regex
+        rejects << [i,
+          Embedly::EmbedlyObject.new(
+            :type => 'error',
+            :error_code => 401,
+            :error_message => 'Embedly api key is required.'
+          )
+        ]
+      elsif url.length > 2048
+        rejects << [i,
+          Embedly::EmbedlyObject.new(
+            :type => 'error',
+            :error_code => 414,
+            :error_message => 'URL too long.'
+          )
+        ]
       end
     end
 


### PR DESCRIPTION
In a recent set of messages with Art, I was informed that we were passing requests that were too long for the API server to handle.  This problem can be alleviated if the API Gem rejects the call first.  I set the max length of the URL to be 2048 characters (as opposed to 2900 which the NGINX starts rejecting) in order to allow for the API key and any other options to be passed.  This should keep the requests to less than 2900 bytes.

In the pull request is the modification as well as the cucumber test to verify it. 
