### PR TITLE
Read key value from Embedly::Configuration

### DIFF
--- a/lib/embedly/api.rb
+++ b/lib/embedly/api.rb
@@ -50,7 +50,7 @@ class Embedly::API
   # [:+headers+] Additional headers to send with requests.
   def initialize opts={}
     @endpoints = [:oembed, :objectify, :preview]
-    @key = opts[:key]
+    @key = opts[:key] || configuration.key
     @secret = opts[:secret] == "" ? nil : opts[:secret]
     @api_version = Hash.new('1')
     @api_version.merge!({:objectify => '2'})


### PR DESCRIPTION
So that the API key doesn't have to be entered every time
Embedly::API is instantiated.
