### PR TITLE
Issue #32 fix deserialization for ruby 2.3.1

### DIFF
--- a/lib/embedly/model.rb
+++ b/lib/embedly/model.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 class Embedly::EmbedlyObject < OpenStruct
 
   # Resursively make ostruct
-  def initialize obj
+  def initialize(obj = nil)
     if obj
       o = obj.clone
       o.each do |k,v|


### PR DESCRIPTION
Deserialization with empty arguments caused Argument Error for Ruby 2.3.1 
Issue https://github.com/embedly/embedly-ruby/issues/32